### PR TITLE
Add raylib and yaml-cpp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,9 @@
 [submodule "extern/googletest"]
 	path = extern/googletest
 	url = https://github.com/google/googletest.git
+[submodule "extern/yaml-cpp"]
+	path = extern/yaml-cpp
+	url = https://github.com/jbeder/yaml-cpp.git
+[submodule "extern/raylib"]
+	path = extern/raylib
+	url = https://github.com/raysan5/raylib.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_BUILD_TYPE Debug)
 cmake_policy(SET CMP0048 NEW)
 
 project(
-  plant
+  _plant
   DESCRIPTION "Python Library for Autonomous Navigation and Tracking"
   LANGUAGES C CXX
 )
@@ -45,17 +45,17 @@ include_directories(${YAML_CPP_INCLUDE_DIRS})
 #===============================================================================
 # build plant
 
-set(SOURCES ${CMAKE_SOURCE_DIR}/src/plant.cc)
+set(SOURCES ${PROJECT_SOURCE_DIR}/src/plant.cc)
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
 target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES})
 target_link_libraries(${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 
 pybind11_add_module(
-  _plant
-  ${CMAKE_SOURCE_DIR}/src/plant.cc
-  ${CMAKE_SOURCE_DIR}/src/core/transforms.cc
-  ${CMAKE_SOURCE_DIR}/src/sensors/imu.cc
+  plant
+  ${PROJECT_SOURCE_DIR}/src/plant.cc
+  ${PROJECT_SOURCE_DIR}/src/core/transforms.cc
+  ${PROJECT_SOURCE_DIR}/src/sensors/imu.cc
 )
 
 target_link_libraries(${PROJECT_NAME} raylib)
@@ -93,8 +93,8 @@ enable_testing()
 
 add_executable(
   v3f_test
-  ${CMAKE_SOURCE_DIR}/tests/v3f_test.cc
-  ${CMAKE_SOURCE_DIR}/src/core/transforms.cc
+  ${PROJECT_SOURCE_DIR}/tests/v3f_test.cc
+  ${PROJECT_SOURCE_DIR}/src/core/transforms.cc
 )
 
 target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,55 +8,54 @@ set(CMAKE_CXX_STANDARD 20)
 
 set(CMAKE_BUILD_TYPE Debug)
 
+set(YAML_BUILD_SHARED_LIBS ON)
+
 cmake_policy(SET CMP0048 NEW)
 
 project(
-  _plant
+  plant
+  VERSION 1.0
   DESCRIPTION "Python Library for Autonomous Navigation and Tracking"
   LANGUAGES C CXX
 )
 
 #===============================================================================
-# external packages
+# configure dependencies
 
 add_subdirectory(extern/googletest)
 add_subdirectory(extern/raylib)
 add_subdirectory(extern/pybind11)
 add_subdirectory(extern/yaml-cpp)
 
-set(raylib_DIR "${CMAKE_SOURCE_DIR}/extern/raylib/cmake")
-set(yaml-cpp_DIR "{CMAKE_SOURCE_DIR}/extern/yaml-cpp")
-
-if (NOT TARGET raylib)
-    find_package(raylib REQUIRED)
-endif()
+set(pybind11_DIR "${PROJECT_SOURCE_DIR}/extern/pybind11")
+set(raylib_DIR "${PROJECT_SOURCE_DIR}/extern/raylib/cmake")
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(raylib REQUIRED)
 
-include_directories(${Python3_INCLUDE_DIRS})
 include_directories(${pybind11_INCLUDE_DIR})
-
-if (NOT TARGET yaml-cpp)
-    find_package(yaml-cpp REQUIRED)
-endif()
-
-include_directories(${YAML_CPP_INCLUDE_DIRS})
+include_directories(${Python3_INCLUDE_DIRS})
+include_directories(${YAML_CPP_INCLUDE_DIR})
 
 #===============================================================================
 # build plant
 
 set(SOURCES ${PROJECT_SOURCE_DIR}/src/plant.cc)
-add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
-target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES})
-target_link_libraries(${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
+add_library(
+    ${PROJECT_NAME}
+    STATIC
+    ${SOURCES}
+)
 
 pybind11_add_module(
-  plant
-  ${PROJECT_SOURCE_DIR}/src/plant.cc
-  ${PROJECT_SOURCE_DIR}/src/core/transforms.cc
-  ${PROJECT_SOURCE_DIR}/src/sensors/imu.cc
+    _plant
+    ${PROJECT_SOURCE_DIR}/src/plant.cc
+    ${PROJECT_SOURCE_DIR}/src/core/transforms.cc
+    ${PROJECT_SOURCE_DIR}/src/sensors/imu.cc
 )
+
+target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES})
 
 target_link_libraries(${PROJECT_NAME} raylib)
 target_link_libraries(${PROJECT_NAME} yaml-cpp)
@@ -66,6 +65,8 @@ if (APPLE)
     target_link_libraries(${PROJECT_NAME} "-framework Cocoa")
     target_link_libraries(${PROJECT_NAME} "-framework OpenGL")
 endif()
+
+target_link_libraries(_plant PRIVATE ${PROJECT_NAME})
 
 #===============================================================================
 # build examples
@@ -77,19 +78,18 @@ add_subdirectory(examples/raylib)
 
 enable_testing()
 
-#add_executable(
-#  parser_test
-#  ${CMAKE_SOURCE_DIR}/tests/parser_test.cc
-#  ${CMAKE_SOURCE_DIR}/src/utils/parser.cc
-#)
+add_executable(
+  parser_test
+  ${PROJECT_SOURCE_DIR}/tests/parser_test.cc
+  ${PROJECT_SOURCE_DIR}/src/utils/parser.cc
+)
 
-#target_link_libraries(
-#  parser_test
-#  PRIVATE
-#  GTest::gtest_main
-#  GTest::gmock_main
-#  ${YAML_CPP_LIBRARIES}
-#)
+target_link_libraries(
+  parser_test
+  GTest::gtest_main
+  GTest::gmock_main
+  yaml-cpp
+)
 
 add_executable(
   v3f_test
@@ -104,5 +104,5 @@ target_link_libraries(
 
 include(GoogleTest)
 
-#gtest_discover_tests(parser_test)
+gtest_discover_tests(parser_test)
 gtest_discover_tests(v3f_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,8 @@ if (NOT TARGET raylib)
 endif()
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
-include_directories(${Python3_INCLUDE_DIRS})
 
+include_directories(${Python3_INCLUDE_DIRS})
 include_directories(${pybind11_INCLUDE_DIR})
 
 if (NOT TARGET yaml-cpp)
@@ -49,7 +49,6 @@ set(SOURCES ${CMAKE_SOURCE_DIR}/src/plant.cc)
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
 target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES})
-
 target_link_libraries(${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 
 pybind11_add_module(
@@ -60,12 +59,7 @@ pybind11_add_module(
 )
 
 target_link_libraries(${PROJECT_NAME} raylib)
-
-#target_link_libraries(
-#    ${PROJECT_NAME}
-#    PRIVATE
-#    yaml-cpp
-#)
+target_link_libraries(${PROJECT_NAME} yaml-cpp)
 
 if (APPLE)
     target_link_libraries(${PROJECT_NAME} "-framework IOKit")
@@ -74,21 +68,28 @@ if (APPLE)
 endif()
 
 #===============================================================================
+# build examples
+
+add_subdirectory(examples/raylib)
+
+#===============================================================================
 # build googletest
 
 enable_testing()
 
-add_executable(
-  parser_test
-  ${CMAKE_SOURCE_DIR}/tests/parser_test.cc
-  ${CMAKE_SOURCE_DIR}/src/utils/parser.cc
-)
+#add_executable(
+#  parser_test
+#  ${CMAKE_SOURCE_DIR}/tests/parser_test.cc
+#  ${CMAKE_SOURCE_DIR}/src/utils/parser.cc
+#)
 
-target_link_libraries(
-  parser_test
-  GTest::gtest_main
-  GTest::gmock_main
-)
+#target_link_libraries(
+#  parser_test
+#  PRIVATE
+#  GTest::gtest_main
+#  GTest::gmock_main
+#  ${YAML_CPP_LIBRARIES}
+#)
 
 add_executable(
   v3f_test
@@ -103,5 +104,5 @@ target_link_libraries(
 
 include(GoogleTest)
 
-gtest_discover_tests(parser_test)
+#gtest_discover_tests(parser_test)
 gtest_discover_tests(v3f_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,12 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_C_COMPILER /usr/bin/gcc)
 set(CMAKE_CXX_COMPILER /usr/bin/g++)
 
+set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 20)
+
+set(CMAKE_BUILD_TYPE Debug)
 
 cmake_policy(SET CMP0048 NEW)
 
@@ -13,8 +16,41 @@ project(
   LANGUAGES C CXX
 )
 
+#===============================================================================
+# external packages
+
 add_subdirectory(extern/googletest)
+add_subdirectory(extern/raylib)
 add_subdirectory(extern/pybind11)
+add_subdirectory(extern/yaml-cpp)
+
+set(raylib_DIR "${CMAKE_SOURCE_DIR}/extern/raylib/cmake")
+set(yaml-cpp_DIR "{CMAKE_SOURCE_DIR}/extern/yaml-cpp")
+
+if (NOT TARGET raylib)
+    find_package(raylib REQUIRED)
+endif()
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+include_directories(${Python3_INCLUDE_DIRS})
+
+include_directories(${pybind11_INCLUDE_DIR})
+
+if (NOT TARGET yaml-cpp)
+    find_package(yaml-cpp REQUIRED)
+endif()
+
+include_directories(${YAML_CPP_INCLUDE_DIRS})
+
+#===============================================================================
+# build plant
+
+set(SOURCES ${CMAKE_SOURCE_DIR}/src/plant.cc)
+add_library(${PROJECT_NAME} SHARED ${SOURCES})
+
+target_link_libraries(${PROJECT_NAME} ${Python3_LIBRARIES})
+
+target_link_libraries(${PROJECT_NAME} ${YAML_CPP_LIBRARIES})
 
 pybind11_add_module(
   _plant
@@ -23,8 +59,22 @@ pybind11_add_module(
   ${CMAKE_SOURCE_DIR}/src/sensors/imu.cc
 )
 
+target_link_libraries(${PROJECT_NAME} raylib)
+
+#target_link_libraries(
+#    ${PROJECT_NAME}
+#    PRIVATE
+#    yaml-cpp
+#)
+
+if (APPLE)
+    target_link_libraries(${PROJECT_NAME} "-framework IOKit")
+    target_link_libraries(${PROJECT_NAME} "-framework Cocoa")
+    target_link_libraries(${PROJECT_NAME} "-framework OpenGL")
+endif()
+
 #===============================================================================
-# googletest
+# build googletest
 
 enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@
 
 ## Build Instructions
 
-#### C++ 
+###### C++ 
 
 ```shell
 cmake -S . -B build
 cmake --build build --target install
 ```
 
-#### Python Bindings
+###### Python bindings
 
 ```shell
 ./scripts/build.sh
@@ -30,20 +30,20 @@ cmake --build build --target install
 
 ## Running Tests / Examples
 
-##### GoogleTest Suite
+###### GoogleTest suite
 
 ```shell
 cd build && ctest
 ```
 
-##### Raylib Example
+###### Raylib example
 
 ```shell
 cd build/examples/raylib
 ./raylib_example
 ```
 
-##### pytest
+###### pytest
 
 ```shell
 ./scripts/test.sh

--- a/README.md
+++ b/README.md
@@ -15,36 +15,29 @@
 
 ## Build Instructions
 
-###### C++ 
-
 ```shell
+git submodule update --init --recursive
 cmake -S . -B build
 cmake --build build --target install
 ```
 
-###### Python bindings
-
-```shell
-./scripts/build.sh
-```
-
 ## Running Tests / Examples
 
-###### GoogleTest suite
+###### GoogleTest Suite
 
 ```shell
 cd build && ctest
 ```
 
-###### Raylib example
+###### Python Test Suite
+
+```shell
+./scripts/test.sh
+```
+
+###### Raylib Example
 
 ```shell
 cd build/examples/raylib
 ./raylib_example
-```
-
-###### pytest
-
-```shell
-./scripts/test.sh
 ```

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@
 
 ## Build and Test
 
-#### Python
-
-```shell
-./scripts/build.sh && ./scripts/test.sh
-```
-
 #### C++
 
 ```shell
 cmake -S . -B build && cmake --build build
 cd build && ctest
+```
+
+#### Python
+
+```shell
+./scripts/build.sh && ./scripts/test.sh
 ```

--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ cmake --build build --target install
 
 ## Running Tests / Examples
 
-###### GoogleTest Suite
+##### GoogleTest Suite
 
 ```shell
 cd build && ctest
 ```
 
-###### Raylib Example
+##### Raylib Example
 
 ```shell
 cd build/examples/raylib
 ./raylib_example
 ```
 
-#### pytest
+##### pytest
 
 ```shell
 ./scripts/test.sh

--- a/README.md
+++ b/README.md
@@ -13,17 +13,38 @@
 ![C++](https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=c%2B%2B&logoColor=white)
 ![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
 
-## Build and Test
+## Build Instructions
 
-#### C++
+#### C++ 
 
 ```shell
-cmake -S . -B build && cmake -DCMAKE_PREFIX_PATH=extern/yaml-cpp --build build
+cmake -S . -B build
+cmake --build build --target install
+```
+
+#### Python Bindings
+
+```shell
+./scripts/build.sh
+```
+
+## Running Tests / Examples
+
+###### GoogleTest Suite
+
+```shell
 cd build && ctest
 ```
 
-#### Python
+###### Raylib Example
 
 ```shell
-./scripts/build.sh && ./scripts/test.sh
+cd build/examples/raylib
+./raylib_example
+```
+
+#### pytest
+
+```shell
+./scripts/test.sh
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 #### C++
 
 ```shell
-cmake -S . -B build && cmake --build build
+cmake -S . -B build && cmake -DCMAKE_PREFIX_PATH=extern/yaml-cpp --build build
 cd build && ctest
 ```
 

--- a/configs/main.yml
+++ b/configs/main.yml
@@ -1,0 +1,10 @@
+globals:
+  total time: 10 sec
+
+integrator:
+  type: rk4
+  step size: 0.01 sec
+
+agents:
+  name: spacecraft
+    - model: point mass

--- a/examples/raylib/CMakeLists.txt
+++ b/examples/raylib/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_executable(raylib_example main.c)
+cmake_minimum_required(VERSION 3.15)
 
-target_link_libraries(
-    raylib_example
-    PRIVATE
-    ../../extern/raylib
-)
+project(raylib_example)
+
+add_executable(${PROJECT_NAME} main.c)
+
+target_link_libraries(${PROJECT_NAME} raylib)

--- a/examples/raylib/CMakeLists.txt
+++ b/examples/raylib/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(raylib_example main.c)
+
+target_link_libraries(
+    raylib_example
+    PRIVATE
+    ../../extern/raylib
+)

--- a/examples/raylib/main.c
+++ b/examples/raylib/main.c
@@ -1,0 +1,16 @@
+#include "raylib.h"
+
+int main(void) {
+    InitWindow(800, 450, "raylib [core] example - basic window");
+
+    while (!WindowShouldClose()) {
+        BeginDrawing();
+        ClearBackground(RAYWHITE);
+        DrawText("congrats! you created your first window!", 190, 200, 20, LIGHTGRAY);
+        EndDrawing();
+    }
+
+    CloseWindow();
+
+    return 0;
+}

--- a/src/core/transforms.cc
+++ b/src/core/transforms.cc
@@ -6,12 +6,12 @@ namespace plant {
 namespace core {
 namespace transforms {
 
-float dot_v3f(plant::core::types::Vector3f u, plant::core::types::Vector3f v) {
+float dot_v3f(types::Vector3f u, types::Vector3f v) {
   return u.x * v.x + u.y * v.y + u.z * v.z;
 }
 
-plant::core::types::Vector3f cross_v3f(plant::core::types::Vector3f u, plant::core::types::Vector3f v) {
-    plant::core::types::Vector3f w = {
+types::Vector3f cross_v3f(types::Vector3f u, types::Vector3f v) {
+    types::Vector3f w = {
         u.y * v.z - u.z * v.y,
         u.z * v.x - u.x * v.z,
         u.x * v.y - u.y * v.x

--- a/src/core/transforms.cc
+++ b/src/core/transforms.cc
@@ -6,12 +6,12 @@ namespace plant {
 namespace core {
 namespace transforms {
 
-float dot_v3f(types::Vector3f u, types::Vector3f v) {
+float dot_v3f(plant::core::types::Vector3f u, plant::core::types::Vector3f v) {
   return u.x * v.x + u.y * v.y + u.z * v.z;
 }
 
-types::Vector3f cross_v3f(types::Vector3f u, types::Vector3f v) {
-    types::Vector3f w = {
+plant::core::types::Vector3f cross_v3f(plant::core::types::Vector3f u, plant::core::types::Vector3f v) {
+    plant::core::types::Vector3f w = {
         u.y * v.z - u.z * v.y,
         u.z * v.x - u.x * v.z,
         u.x * v.y - u.y * v.x

--- a/src/plant.cc
+++ b/src/plant.cc
@@ -121,8 +121,19 @@ PYBIND11_MODULE(_plant, m) {
   //----------------------------------------------------------------------------------------------------
   // methods
 
-  // m_transforms.def("dot_v3f", &plant::core::transforms::dot_v3f);
-  // m_transforms.def("cross_v3f", &plant::core::transforms::cross_v3f);
+  m_transforms.def(
+    "dot_v3f",
+    &plant::core::transforms::dot_v3f,
+    py::arg("u"),
+    py::arg("v")
+  );
+
+  m_transforms.def(
+    "cross_v3f",
+    &plant::core::transforms::cross_v3f,
+    py::arg("u"),
+    py::arg("v")
+  );
 
   //====================================================================================================
   // create the "sensors" module and add the imu to it

--- a/src/plant.cc
+++ b/src/plant.cc
@@ -121,8 +121,8 @@ PYBIND11_MODULE(_plant, m) {
   //----------------------------------------------------------------------------------------------------
   // methods
 
-  m_transforms.def("dot_v3f", &plant::core::transforms::dot_v3f);
-  m_transforms.def("cross_v3f", &plant::core::transforms::cross_v3f);
+  // m_transforms.def("dot_v3f", &plant::core::transforms::dot_v3f);
+  // m_transforms.def("cross_v3f", &plant::core::transforms::cross_v3f);
 
   //====================================================================================================
   // create the "sensors" module and add the imu to it

--- a/src/utils/parser.cc
+++ b/src/utils/parser.cc
@@ -1,3 +1,5 @@
 /** @file Source file for parsing .yaml configuration file(s) */
 
+#include <yaml-cpp/yaml.h>
+
 #include "./parser.h"

--- a/tests/v3f_test.cc
+++ b/tests/v3f_test.cc
@@ -3,8 +3,6 @@
 #include "../src/core/transforms.h"
 #include "../src/core/types.h"
 
-// first argument is the name of the test suite
-// second argument is the name of the test within the test suite
 TEST(Vector3fTest, AdditionOperator) {
   plant::core::types::Vector3f u = {1.0, 2.0, 3.0};
   plant::core::types::Vector3f v = {-1.0, -2.0, -3.0};


### PR DESCRIPTION
This PR adds two new submodules to `plant`:

Package | Purpose
---------|---------
`raylib` | Will be used to visualize object / reference frame orientations, playback streaming, etc.
`yaml-cpp` | Will be used to parse input .yml files and configure sims